### PR TITLE
Remove separate Skeleton linked-documents page and register RzSkeleto…

### DIFF
--- a/src/RizzyUI.Docs/Components/Pages/Components/SkeletonInfo.razor
+++ b/src/RizzyUI.Docs/Components/Pages/Components/SkeletonInfo.razor
@@ -1,0 +1,185 @@
+@page "/components/skeleton"
+@using RizzyUI
+
+<PageTitle>RzSkeleton</PageTitle>
+
+<RzQuickReferenceContainer>
+    <RzArticle ProseWidth="ProseWidth.UltraWide">
+        <SideContent>
+            <RzQuickReference />
+        </SideContent>
+        <MainContent>
+            <RzHeading Level="HeadingLevel.H1" class="scroll-mt-20">
+                RzSkeleton
+            </RzHeading>
+            <RzParagraph>
+                The RzSkeleton component reproduces the shadcn/ui skeleton pattern as a feedback placeholder for loading states.
+                Use it to reserve layout space while async content is loading.
+            </RzParagraph>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Usage" class="scroll-mt-20">Usage</RzHeading>
+                <RzBrowser Layout="typeof(PreviewLayout)">
+                    <div class="mx-auto p-8 mb-5 flex justify-center items-center min-h-20">
+                        <RzSkeleton class="h-5 w-24 rounded-full" />
+                    </div>
+                </RzBrowser>
+                <RzCodeViewer Language="@CodeLanguage.Razor" class="mb-10">&lt;RzSkeleton class=&quot;h-5 w-24 rounded-full&quot; /&gt;</RzCodeViewer>
+            </section>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Avatar" class="scroll-mt-20">Avatar</RzHeading>
+                <RzBrowser Layout="typeof(PreviewLayout)">
+                    <div class="mx-auto p-8 mb-5 flex w-fit items-center gap-4">
+                        <RzSkeleton class="size-10 shrink-0 rounded-full" />
+                        <div class="grid gap-2">
+                            <RzSkeleton class="h-4 w-[150px]" />
+                            <RzSkeleton class="h-4 w-[100px]" />
+                        </div>
+                    </div>
+                </RzBrowser>
+                <RzCodeViewer Language="@CodeLanguage.Razor" class="mb-10">
+                    &lt;div class=&quot;flex w-fit items-center gap-4&quot;&gt;
+                        &lt;RzSkeleton class=&quot;size-10 shrink-0 rounded-full&quot; /&gt;
+                        &lt;div class=&quot;grid gap-2&quot;&gt;
+                            &lt;RzSkeleton class=&quot;h-4 w-[150px]&quot; /&gt;
+                            &lt;RzSkeleton class=&quot;h-4 w-[100px]&quot; /&gt;
+                        &lt;/div&gt;
+                    &lt;/div&gt;
+                </RzCodeViewer>
+            </section>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Card" class="scroll-mt-20">Card</RzHeading>
+                <RzBrowser Layout="typeof(PreviewLayout)">
+                    <div class="mx-auto p-8 mb-5 w-full max-w-xs rounded-lg border bg-background">
+                        <div class="space-y-2 p-6">
+                            <RzSkeleton class="h-4 w-2/3" />
+                            <RzSkeleton class="h-4 w-1/2" />
+                        </div>
+                        <div class="px-6 pb-6">
+                            <RzSkeleton class="aspect-video w-full" />
+                        </div>
+                    </div>
+                </RzBrowser>
+                <RzCodeViewer Language="@CodeLanguage.Razor" class="mb-10">
+                    &lt;RzSkeleton class=&quot;h-4 w-2/3&quot; /&gt;
+                    &lt;RzSkeleton class=&quot;h-4 w-1/2&quot; /&gt;
+                    &lt;RzSkeleton class=&quot;aspect-video w-full&quot; /&gt;
+                </RzCodeViewer>
+            </section>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Text" class="scroll-mt-20">Text</RzHeading>
+                <RzBrowser Layout="typeof(PreviewLayout)">
+                    <div class="mx-auto p-8 mb-5 flex w-full max-w-xs flex-col gap-2">
+                        <RzSkeleton class="h-4 w-full" />
+                        <RzSkeleton class="h-4 w-full" />
+                        <RzSkeleton class="h-4 w-3/4" />
+                    </div>
+                </RzBrowser>
+                <RzCodeViewer Language="@CodeLanguage.Razor" class="mb-10">
+                    &lt;RzSkeleton class=&quot;h-4 w-full&quot; /&gt;
+                    &lt;RzSkeleton class=&quot;h-4 w-full&quot; /&gt;
+                    &lt;RzSkeleton class=&quot;h-4 w-3/4&quot; /&gt;
+                </RzCodeViewer>
+            </section>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Form" class="scroll-mt-20">Form</RzHeading>
+                <RzBrowser Layout="typeof(PreviewLayout)">
+                    <div class="mx-auto p-8 mb-5 flex w-full max-w-xs flex-col gap-7">
+                        <div class="flex flex-col gap-3">
+                            <RzSkeleton class="h-4 w-20" />
+                            <RzSkeleton class="h-8 w-full" />
+                        </div>
+                        <div class="flex flex-col gap-3">
+                            <RzSkeleton class="h-4 w-24" />
+                            <RzSkeleton class="h-8 w-full" />
+                        </div>
+                        <RzSkeleton class="h-8 w-24" />
+                    </div>
+                </RzBrowser>
+                <RzCodeViewer Language="@CodeLanguage.Razor" class="mb-10">
+                    &lt;RzSkeleton class=&quot;h-4 w-20&quot; /&gt;
+                    &lt;RzSkeleton class=&quot;h-8 w-full&quot; /&gt;
+                    &lt;RzSkeleton class=&quot;h-8 w-24&quot; /&gt;
+                </RzCodeViewer>
+            </section>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Table" class="scroll-mt-20">Table</RzHeading>
+                <RzBrowser Layout="typeof(PreviewLayout)">
+                    <div class="mx-auto p-8 mb-5 flex w-full max-w-sm flex-col gap-2">
+                        @for (var index = 0; index < 5; index++)
+                        {
+                            <div class="flex gap-4">
+                                <RzSkeleton class="h-4 flex-1" />
+                                <RzSkeleton class="h-4 w-24" />
+                                <RzSkeleton class="h-4 w-20" />
+                            </div>
+                        }
+                    </div>
+                </RzBrowser>
+                <RzCodeViewer Language="@CodeLanguage.Razor" class="mb-10">
+                    &lt;RzSkeleton class=&quot;h-4 flex-1&quot; /&gt;
+                    &lt;RzSkeleton class=&quot;h-4 w-24&quot; /&gt;
+                    &lt;RzSkeleton class=&quot;h-4 w-20&quot; /&gt;
+                </RzCodeViewer>
+            </section>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Media List" class="scroll-mt-20">Media List</RzHeading>
+                <RzBrowser Layout="typeof(PreviewLayout)">
+                    <div class="mx-auto p-8 mb-5 max-w-lg space-y-4">
+                        @for (var i = 0; i < 3; i++)
+                        {
+                            <div class="flex items-start gap-4">
+                                <RzSkeleton class="h-14 w-14 rounded-md" />
+                                <div class="space-y-2 w-full">
+                                    <RzSkeleton class="h-4 w-1/2" />
+                                    <RzSkeleton class="h-4 w-full" />
+                                    <RzSkeleton class="h-4 w-4/5" />
+                                </div>
+                            </div>
+                        }
+                    </div>
+                </RzBrowser>
+            </section>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Dashboard Cards" class="scroll-mt-20">Dashboard Cards</RzHeading>
+                <RzBrowser Layout="typeof(PreviewLayout)">
+                    <div class="mx-auto p-8 mb-5 grid max-w-3xl gap-4 md:grid-cols-3">
+                        @for (var i = 0; i < 3; i++)
+                        {
+                            <div class="space-y-3 rounded-lg border p-4">
+                                <RzSkeleton class="h-4 w-1/3" />
+                                <RzSkeleton class="h-8 w-1/2" />
+                                <RzSkeleton class="h-3 w-2/3" />
+                            </div>
+                        }
+                    </div>
+                </RzBrowser>
+            </section>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Chat Messages" class="scroll-mt-20">Chat Messages</RzHeading>
+                <RzBrowser Layout="typeof(PreviewLayout)">
+                    <div class="mx-auto p-8 mb-5 max-w-xl space-y-4">
+                        <div class="flex justify-start"><RzSkeleton class="h-10 w-2/3 rounded-2xl" /></div>
+                        <div class="flex justify-end"><RzSkeleton class="h-10 w-1/2 rounded-2xl" /></div>
+                        <div class="flex justify-start"><RzSkeleton class="h-10 w-3/4 rounded-2xl" /></div>
+                    </div>
+                </RzBrowser>
+            </section>
+
+            <section class="my-8 py-2">
+                <RzHeading Level="HeadingLevel.H2" QuickReferenceTitle="Complex Page" class="scroll-mt-20">Complex Page</RzHeading>
+                <RzParagraph>
+                    Compose multiple RzSkeleton groups to build realistic placeholders for entire pages while data loads.
+                </RzParagraph>
+            </section>
+        </MainContent>
+    </RzArticle>
+</RzQuickReferenceContainer>

--- a/src/RizzyUI/AGENTS.md
+++ b/src/RizzyUI/AGENTS.md
@@ -49,9 +49,9 @@ When the user requests code, wrap each file in a single **`output` block** so au
 ```razor
 <HtmlElement Element="@EffectiveElement"
              id="@Id"
+             @attributes="@AdditionalAttributes"
              class="@SlotClasses.GetBase()"
-             data-slot="fancy-thing"
-             @attributes="@AdditionalAttributes">
+             data-slot="fancy-thing">
     @* Optional content here, like an Alpine child-container *@
 </HtmlElement>
 ```
@@ -62,6 +62,7 @@ When the user requests code, wrap each file in a single **`output` block** so au
 *   `data-slot="component-name"` is a **mandatory** attribute. The value should be the kebab-case version of the component's name (e.g., `RzFancyThing` becomes `fancy-thing`).
 *   **Always** convert enum values used as data- attributes into kebab-case (e.g. MyEnumProperty.ToString().ToKebabCase()).
 *   **Always** write `@attributes="@AdditionalAttributes"` (note the leading `@`).
+*   **Always place `@attributes` before `class`** on component root elements.
 *   **Never** use @* *@ comments inside Razor markup for elements that will be rendered.
 *   To change the `Element` type, override `OnInitialized()` in the code-behind. Set `Element` to the new type only if `Element` is empty or null.
     ```csharp
@@ -548,7 +549,7 @@ Alpine.data('counter', () => ({
 If a RizzyUI component uses Alpine.js, its root `<HtmlElement>` in the `.razor` file MUST contain a direct child `<div>` with the following attributes. This `div` serves as the root for the Alpine component.
 
 ```razor
-<HtmlElement Element="@EffectiveElement" id="@Id" class="@SlotClasses.GetBase()" @attributes="@AdditionalAttributes">
+<HtmlElement Element="@EffectiveElement" id="@Id" @attributes="@AdditionalAttributes" class="@SlotClasses.GetBase()">
     <div data-alpine-root="@Id" @* Crucial: Must match the Blazor component's @Id *@
          x-data="rzFancyThing"   @* Alpine component name, e.g., 'rzComponentName' *@
          data-assets="@_assets"   @* Serialized JSON string of asset URLs for this component *@

--- a/src/RizzyUI/Components/Feedback/RzSkeleton/RzSkeleton.razor
+++ b/src/RizzyUI/Components/Feedback/RzSkeleton/RzSkeleton.razor
@@ -1,0 +1,10 @@
+@namespace RizzyUI
+@inherits RzComponent<RzSkeleton.Slots>
+
+<HtmlElement Element="@EffectiveElement"
+             id="@Id"
+             @attributes="@AdditionalAttributes"
+             class="@SlotClasses.GetBase()"
+             data-slot="skeleton">
+    @ChildContent
+</HtmlElement>

--- a/src/RizzyUI/Components/Feedback/RzSkeleton/RzSkeleton.razor.cs
+++ b/src/RizzyUI/Components/Feedback/RzSkeleton/RzSkeleton.razor.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Components;
+using TailwindVariants.NET;
+
+namespace RizzyUI;
+
+/// <summary>
+/// Displays a pulsing placeholder block while content is loading.
+/// </summary>
+public partial class RzSkeleton : RzComponent<RzSkeleton.Slots>
+{
+    /// <summary>
+    /// Defines the default styling for the RzSkeleton component.
+    /// </summary>
+    public static readonly TvDescriptor<RzComponent<Slots>, Slots> DefaultDescriptor = new(
+        @base: "bg-accent animate-pulse rounded-md"
+    );
+
+    /// <summary>
+    /// Optional content rendered inside the skeleton container.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <inheritdoc />
+    protected override TvDescriptor<RzComponent<Slots>, Slots> GetDescriptor() => Theme.RzSkeleton;
+
+    /// <summary>
+    /// Defines the slots available for styling in the RzSkeleton component.
+    /// </summary>
+    public sealed partial class Slots : ISlots
+    {
+        /// <summary>
+        /// The base slot for the component's root element.
+        /// </summary>
+        [Slot("skeleton")]
+        public string? Base { get; set; }
+    }
+}

--- a/src/RizzyUI/RzTheme.StyleProviders.cs
+++ b/src/RizzyUI/RzTheme.StyleProviders.cs
@@ -105,6 +105,8 @@ public partial class RzTheme
     public virtual TvDescriptor<RzComponent<RzSheet.Slots>, RzSheet.Slots> RzSheet { get; set; }
     /// <summary> Gets or sets the style definitions for the <see cref="RizzyUI.RzSpinner"/> component. </summary>
     public virtual TvDescriptor<RzComponent<RzSpinner.Slots>, RzSpinner.Slots> RzSpinner { get; set; }
+    /// <summary> Gets or sets the style definitions for the <see cref="RizzyUI.RzSkeleton"/> component. </summary>
+    public virtual TvDescriptor<RzComponent<RzSkeleton.Slots>, RzSkeleton.Slots> RzSkeleton { get; set; }
     /// <summary> Gets or sets the style definitions for the <see cref="RizzyUI.SheetClose"/> component. </summary>
     public virtual TvDescriptor<RzAsChildComponent<SheetClose.Slots>, SheetClose.Slots> SheetClose { get; set; }
     /// <summary> Gets or sets the style definitions for the <see cref="RizzyUI.SheetContent"/> component. </summary>

--- a/src/RizzyUI/RzTheme.cs
+++ b/src/RizzyUI/RzTheme.cs
@@ -276,6 +276,9 @@ public partial class RzTheme
         // RzSpinner Family
         RzSpinner = RizzyUI.RzSpinner.DefaultDescriptor;
 
+        // RzSkeleton Family
+        RzSkeleton = RizzyUI.RzSkeleton.DefaultDescriptor;
+
         // RzSteps Family
         RzSteps = RizzyUI.RzSteps.DefaultDescriptor;
 


### PR DESCRIPTION
…n component (#10)

* Add Scroll Area docs page and tests (#5)

* Add ScrollArea docs page and navigation tests

* Add ScrollArea orientation enum and descriptor variants

* Use existing Orientation enum in RzScrollArea

* Implement Alpine-powered Radix-style behavior for RzScrollArea

* Shift RzScrollArea to TV-first scrollbar state styling

* Align RzScrollArea Alpine markup with CSP-safe conventions

* chore: update build scripts and file paths

Renames instruction file and updates npm script references to reflect new file name. Modifies ignore paths in build script. Removes redundant build target in project configuration.

* feat(rzScrollArea): enhance lifecycle methods

Introduce `_viewport` property to cache viewport reference and streamline access. Refactor cleanup logic into `destroy` method for better lifecycle management.

Contributes to improved component reliability and maintainability.

* chore: update generated files

* docs: refresh scroll area and scrollbar documentation (#7)

* Remove skeleton linked-documents page and keep sidebar-integrated docs

* Expand RzSkeleton docs with comprehensive loading examples

* Enforce @attributes ordering and expand Skeleton docs examples