### PR TITLE
docs: update pagination naming convention

### DIFF
--- a/src/RizzyUI.Docs/Components/Pages/Components/PaginationInfo.razor
+++ b/src/RizzyUI.Docs/Components/Pages/Components/PaginationInfo.razor
@@ -25,7 +25,7 @@
                 </BreadcrumbList>
             </RzBreadcrumb>
 
-            <RzHeading Level="HeadingLevel.H1" QuickReferenceTitle="RzPagination" class="scroll-mt-20">RzPagination</RzHeading>
+            <RzHeading Level="HeadingLevel.H1" QuickReferenceTitle="Pagination" class="scroll-mt-20">Pagination</RzHeading>
             <RzParagraph>
                 <strong>RzPagination</strong> is a composable pagination navigation pattern for long lists and result sets. The component family follows a modular structure—
                 <code class="font-semibold">RzPagination</code>, <code class="font-semibold">PaginationList</code>, <code class="font-semibold">PaginationItem</code>,


### PR DESCRIPTION
Renames pagination title for clarity and consistency within the navigation component documentation.