### PR TITLE
docs: update license with Commons Clause

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,8 @@
 # RizzyUI
 
-MIT License
+MIT + Commons Clause License Condition v1.0
 
-Copyright (c) 2024 Michael Tanczos 
+Copyright (c) 2026 Michael Tanczos 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Commons Clause Restriction
+You may use this Software, including for any commercial purpose, so long as you do not sell, sublicense, or redistribute the components themselves-whether alone, in a bundle, or as a ported version.
 
 
 # Attributions


### PR DESCRIPTION
Switches to MIT + Commons Clause License to restrict software sales and sublicensing. Updates copyright year to 2026.

Relates to mat-update-dependencies