### PR TITLE
refactor: Refines field component naming and popover styling

### DIFF
--- a/src/RizzyUI.Docs/Components/Examples/AppearanceSettings.razor
+++ b/src/RizzyUI.Docs/Components/Examples/AppearanceSettings.razor
@@ -37,9 +37,9 @@
                 </RzRadioGroup>
             </RzFieldSet>
 
-            <RzFieldSeparator />
+            <FieldSeparator />
 
-            <RzField Orientation="Orientation.Horizontal">
+            <Field Orientation="FieldOrientation.Horizontal">
                 <FieldContent>
                     <FieldLabel For="() => _model.GpuCount">Number of GPUs</FieldLabel>
                     <FieldDescription>You can add more later.</FieldDescription>
@@ -53,11 +53,11 @@
                         <Blazicon Svg="@Lucide.Plus" />
                     </RzButton>
                 </RzButtonGroup>
-            </RzField>
+            </Field>
 
-            <RzFieldSeparator />
+            <FieldSeparator />
 
-            <RzField Orientation="Orientation.Horizontal">
+            <Field Orientation="FieldOrientation.Horizontal">
                 <FieldContent>
                     <FieldLabel For="() => _model.WallpaperTinting">Wallpaper Tinting</FieldLabel>
                     <FieldDescription>
@@ -65,7 +65,7 @@
                     </FieldDescription>
                 </FieldContent>
                 <RzSwitch id="tinting" For="@(() => _model.WallpaperTinting)" />
-            </RzField>
+            </Field>
         </RzFieldGroup>
     </RzFieldSet>
 </EditForm>

--- a/src/RizzyUI/Components/Feedback/RzPopover/PopoverTrigger.razor.cs
+++ b/src/RizzyUI/Components/Feedback/RzPopover/PopoverTrigger.razor.cs
@@ -59,7 +59,7 @@ public partial class PopoverTrigger : RzAsChildComponent<PopoverTrigger.Slots>
         var attributes = new Dictionary<string, object?>(AdditionalAttributes?.ToDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value) ?? new Dictionary<string, object?>(), StringComparer.OrdinalIgnoreCase)
         {
             ["id"] = TriggerId,
-            ["class"] = SlotClasses.GetBase(),
+            ["class"] = AsChild ? null : SlotClasses.GetBase(),
             ["x-ref"] = "trigger",
             ["x-on:click"] = "toggle",
             ["aria-haspopup"] = "dialog",


### PR DESCRIPTION
Standardizes field-related component names and their orientation property for improved clarity and consistency.

Adjusts popover trigger class application to prevent base styles from interfering when rendered as a child element.