### PR TITLE
refactor: enhance example component usage

### DIFF
--- a/src/RizzyUI.Docs/Components/Examples/AppearanceSettings.razor
+++ b/src/RizzyUI.Docs/Components/Examples/AppearanceSettings.razor
@@ -10,31 +10,28 @@
                 <FieldDescription>
                     Select the compute environment for your cluster.
                 </FieldDescription>
-                <RzRadioGroup For="@(() => _model.Environment)" class="mt-4">
-                    <FieldLabel For="() => _model.Environment" class="cursor-pointer">
-                        <Field Orientation="FieldOrientation.Horizontal">
-                            <FieldContent>
-                                <FieldTitle>Kubernetes</FieldTitle>
-                                <FieldDescription>
-                                    Run GPU workloads on a K8s configured cluster. This is the
-                                    default.
-                                </FieldDescription>
-                            </FieldContent>
-                            <RadioGroupItem Value="@("kubernetes")" id="kubernetes-r2h" aria-label="Kubernetes" />
-                        </Field>
-                    </FieldLabel>
-                    <FieldLabel For="(() => _model.Environment)" class="cursor-pointer">
-                        <Field Orientation="@FieldOrientation.Horizontal">
-                            <FieldContent>
-                                <FieldTitle>Virtual Machine</FieldTitle>
-                                <FieldDescription>
+                <RzRadioGroup For="@(() => _model.Environment)" DisplayName="Environment">
+                    <RadioGroupItem TValue="string" Value="@("kubernetes")">
+                        <div class="bg-background relative flex w-full cursor-pointer items-start space-x-3 rounded-lg border p-4 shadow-sm transition-colors group-has-[.peer:checked]:border-primary hover:bg-accent">
+                            <div class="grid gap-1.5 leading-none">
+                                <span class="font-medium">Kubernetes</span>
+                                <p class="text-muted-foreground text-sm">
+                                    Run GPU workloads on a K8s configured cluster. This is the default.
+                                </p>
+                            </div>
+                        </div>
+                    </RadioGroupItem>
+                    <RadioGroupItem TValue="string" Value="@("vm")">
+                        <div class="bg-background relative flex w-full cursor-pointer items-start space-x-3 rounded-lg border p-4 shadow-sm transition-colors group-has-[.peer:checked]:border-primary hover:bg-accent">
+                            <div class="grid gap-1.5 leading-none">
+                                <span class="font-medium">Virtual Machine</span>
+                                <p class="text-muted-foreground text-sm">
                                     Access a VM configured cluster to run workloads. (Coming soon)
-                                </FieldDescription>
-                            </FieldContent>
-                            <RadioGroupItem Value="@("vm")" id="vm-z4k" aria-label="Virtual Machine" />
-                        </Field>
-                    </FieldLabel>
-                </RzRadioGroup>
+                                </p>
+                            </div>
+                        </div>
+                    </RadioGroupItem>
+                </RzRadioGroup>                
             </RzFieldSet>
 
             <FieldSeparator />

--- a/src/RizzyUI.Docs/Components/Examples/ButtonGroupNested.razor
+++ b/src/RizzyUI.Docs/Components/Examples/ButtonGroupNested.razor
@@ -4,22 +4,22 @@
 
 <RzButtonGroup>
     <RzButtonGroup>
-        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.Small">
+        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.ExtraSmall">
             1
         </RzButton>
-        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.Small">
+        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.ExtraSmall">
             2
         </RzButton>
-        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.Small">
+        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.ExtraSmall">
             3
         </RzButton>
     </RzButtonGroup>
     <RzButtonGroup>
-        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.Small" aria-label="Previous">
-            <Blazicon Svg="Lucide.ArrowLeft" />
+        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.ExtraSmall" aria-label="Previous">
+            <Blazicon Svg="@Lucide.ArrowLeft" />
         </RzButton>
-        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.Small" aria-label="Next">
-            <Blazicon Svg="Lucide.ArrowRight" />
+        <RzButton Variant="ThemeVariant.Default" Outline Size="Size.ExtraSmall" aria-label="Next">
+            <Blazicon Svg="@Lucide.ArrowRight" />
         </RzButton>
     </RzButtonGroup>
 </RzButtonGroup>

--- a/src/RizzyUI.Docs/Components/Examples/ButtonGroupPopover.razor
+++ b/src/RizzyUI.Docs/Components/Examples/ButtonGroupPopover.razor
@@ -3,13 +3,13 @@
 @using RizzyUI
 
 <RzButtonGroup>
-    <RzButton Variant="ThemeVariant.Default" Outline Size="Size.Small">
+    <RzButton Variant="ThemeVariant.Default" Outline Size="Size.ExtraSmall">
         <Blazicon Svg="Lucide.Bot" /> Copilot
     </RzButton>
     <RzPopover Anchor="AnchorPoint.BottomEnd">
         <PopoverTrigger AsChild>
-            <RzButton Variant="ThemeVariant.Default" Outline Size="Size.Small" aria-label="Open Popover">
-                <Blazicon Svg="Lucide.ChevronDown" />
+            <RzButton Variant="ThemeVariant.Default" Outline Size="Size.ExtraSmall" aria-label="Open Popover">
+                <Blazicon Svg="@Lucide.ChevronDown" />
             </RzButton>
         </PopoverTrigger>
         <PopoverContent class="gap-0 rounded-xl p-0 text-sm">

--- a/src/RizzyUI.Docs/Components/Examples/FieldCheckbox.razor
+++ b/src/RizzyUI.Docs/Components/Examples/FieldCheckbox.razor
@@ -4,12 +4,12 @@
 
 <EditForm Model="_model">
     <FieldLabel For="() => _model.Agreed">
-        <RzField Orientation="Orientation.Horizontal">
+        <Field Orientation="FieldOrientation.Horizontal">
             <RzInputCheckbox id="checkbox-demo" For="@(() => _model.Agreed)" />
             <FieldLabel For="(() => _model.Agreed)" class="line-clamp-1">
                 I agree to the terms and conditions
             </FieldLabel>
-        </RzField>
+        </Field>
     </FieldLabel>
 </EditForm>
 

--- a/src/RizzyUI.Docs/Components/Examples/InputGroupDemo.razor
+++ b/src/RizzyUI.Docs/Components/Examples/InputGroupDemo.razor
@@ -3,7 +3,7 @@
 @using RizzyUI
 
 <div class="grid w-full max-w-sm gap-6">
-    <EditForm Model="_model">
+    <EditForm Model="_model" x-data @submit.prevent>
         <RzInputGroup>
             <InputGroupInput For="@(() => _model.Search)" Placeholder="Search..." />
             <InputGroupAddon>


### PR DESCRIPTION
Refactors component examples to improve presentation and standardize usage.

- Updates the radio group example to utilize a custom layout for items, offering greater styling flexibility.
- Adjusts button sizes in group and popover examples to `ExtraSmall` for a more compact display.
- Corrects SVG binding syntax in several examples.
- Standardizes Field component usage by removing redundant prefixes.
- Adds Alpine.js attributes for form submission handling in an input group example.