### PR TITLE
feat: scrolls to top on sidebar navigation

### DIFF
--- a/src/RizzyUI.Docs/Components/Layout/MainLayout.razor
+++ b/src/RizzyUI.Docs/Components/Layout/MainLayout.razor
@@ -37,7 +37,7 @@
                     </SidebarMenuItem>
                     <SidebarMenuItem>
                         <SidebarMenuButton AsChild>
-                            <a href="/components" class="font-medium" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML">Components</a>
+                            <a href="/components" class="font-medium" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top">Components</a>
                         </SidebarMenuButton>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
@@ -45,16 +45,16 @@
                             <a href="#" class="font-medium">Interactivity</a>
                         </SidebarMenuButton>
                         <SidebarMenuSub>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/introduction" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Introduction</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/alpine-fundamentals" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Alpine.js Fundamentals</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/alpine-code-behind" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Your First Code-Behind</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/state-reactivity" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>State and Reactivity</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/lifecycle" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Lifecycle and Initialization</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/lazy-loading" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Optimizing with Lazy Loading</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/plugins" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Plugins & Directives</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/orchestration" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Advanced: Orchestration</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/debugging" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Debugging and Best Practices</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/co-located-js" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Additional Examples</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/introduction" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Introduction</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/alpine-fundamentals" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Alpine.js Fundamentals</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/alpine-code-behind" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Your First Code-Behind</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/state-reactivity" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>State and Reactivity</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/lifecycle" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Lifecycle and Initialization</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/lazy-loading" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Optimizing with Lazy Loading</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/plugins" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Plugins & Directives</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/orchestration" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Advanced: Orchestration</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/docs/interactivity/debugging" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Debugging and Best Practices</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/co-located-js" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Additional Examples</span></a></SidebarMenuButton></SidebarMenuItem>
                         </SidebarMenuSub>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
@@ -62,13 +62,13 @@
                             <a href="#" class="font-medium">Display</a>
                         </SidebarMenuButton>
                         <SidebarMenuSub>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/avatar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Avatar</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/badge" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Badge</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/kbd" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Kbd</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/item" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Item</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/separator" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Separator</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/table" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Table</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/progress" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Progress</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/avatar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Avatar</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/badge" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Badge</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/kbd" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Kbd</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/item" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Item</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/separator" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Separator</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/table" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Table</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/progress" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Progress</span></a></SidebarMenuButton></SidebarMenuItem>
                         </SidebarMenuSub>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
@@ -76,16 +76,16 @@
                             <a href="#" class="font-medium">Feedback</a>
                         </SidebarMenuButton>
                         <SidebarMenuSub>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/alert" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Alert</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/alert-dialog" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Alert Dialog</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/dialog" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Dialog</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/toastnotification" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Toast Notification</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/tooltip" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Tooltip</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/sheet" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Sheet</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/empty" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Empty</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/spinner" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Spinner</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/skeleton" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Skeleton</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/steps" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Steps</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/alert" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Alert</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/alert-dialog" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Alert Dialog</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/dialog" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Dialog</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/toastnotification" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Toast Notification</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/tooltip" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Tooltip</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/sheet" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Sheet</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/empty" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Empty</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/spinner" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Spinner</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/skeleton" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Skeleton</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/steps" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Steps</span></a></SidebarMenuButton></SidebarMenuItem>
                         </SidebarMenuSub>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
@@ -93,15 +93,15 @@
                             <a href="#" class="font-medium">Charts</a>
                         </SidebarMenuButton>
                         <SidebarMenuSub>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Chart</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-bar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Bar Chart</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-line" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Line Chart</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-bubble" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Bubble Chart</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-doughnut-pie" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Doughnut & Pie</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-mixed" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Mixed Charts</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-polar-area" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Polar Area</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-radar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Radar Chart</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-scatter" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Scatter Chart</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Chart</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-bar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Bar Chart</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-line" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Line Chart</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-bubble" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Bubble Chart</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-doughnut-pie" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Doughnut & Pie</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-mixed" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Mixed Charts</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-polar-area" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Polar Area</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-radar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Radar Chart</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-scatter" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Scatter Chart</span></a></SidebarMenuButton></SidebarMenuItem>
                             <RzCollapsible class="group/collapsible" DefaultOpen="false">
                                 <SidebarGroup class="p-0">
                                     <SidebarGroupLabel AsChild class="group/label text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm">
@@ -114,13 +114,13 @@
                                         <SidebarGroupContent>
                                             <SidebarMenu>
                                                 <SidebarMenuSub>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-colors" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Colors</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-decimation" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Decimation</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-filler" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Filler</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-legend" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Legend</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-subtitle" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Subtitle</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-title" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Title</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-tooltip" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Tooltip</span></a></SidebarMenuButton></SidebarMenuItem>                                                </SidebarMenuSub>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-colors" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Colors</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-decimation" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Decimation</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-filler" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Filler</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-legend" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Legend</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-subtitle" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Subtitle</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-title" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Title</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-tooltip" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Tooltip</span></a></SidebarMenuButton></SidebarMenuItem>                                                </SidebarMenuSub>
                                             </SidebarMenu>
                                         </SidebarGroupContent>
                                     </CollapsibleContent>
@@ -138,12 +138,12 @@
                                         <SidebarGroupContent>
                                             <SidebarMenu>
                                                 <SidebarMenuSub>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-scales" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Axis Scales</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-border" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Axis Border</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-callbacks" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Axis Callbacks</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-grid" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Axis Grid</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-ticks" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Axis Ticks</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-title" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Axis Title</span></a></SidebarMenuButton></SidebarMenuItem> 
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-scales" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Axis Scales</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-border" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Axis Border</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-callbacks" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Axis Callbacks</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-grid" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Axis Grid</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-ticks" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Axis Ticks</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-axis-title" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Axis Title</span></a></SidebarMenuButton></SidebarMenuItem> 
                                                 </SidebarMenuSub>
                                             </SidebarMenu>
                                         </SidebarGroupContent>
@@ -162,10 +162,10 @@
                                         <SidebarGroupContent>
                                             <SidebarMenu>
                                                 <SidebarMenuSub>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-element-arc" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Arc</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-element-bar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Bar</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-element-line" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Line</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-element-point" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Point</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-element-arc" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Arc</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-element-bar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Bar</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-element-line" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Line</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-element-point" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Point</span></a></SidebarMenuButton></SidebarMenuItem>
                                                 </SidebarMenuSub>
                                             </SidebarMenu>
                                         </SidebarGroupContent>
@@ -184,12 +184,12 @@
                                         <SidebarGroupContent>
                                             <SidebarMenu>
                                                 <SidebarMenuSub>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-animation" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Animation</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-configuration" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Configuration</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-font" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Font</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-interaction" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Interaction</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-layout" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Layout</span></a></SidebarMenuButton></SidebarMenuItem>
-                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-padding" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Padding</span></a></SidebarMenuButton></SidebarMenuItem>                                                    
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-animation" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Animation</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-configuration" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Configuration</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-font" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Font</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-interaction" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Interaction</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-layout" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Layout</span></a></SidebarMenuButton></SidebarMenuItem>
+                                                    <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/chart-padding" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Padding</span></a></SidebarMenuButton></SidebarMenuItem>                                                    
                                                 </SidebarMenuSub>
                                             </SidebarMenu>
                                         </SidebarGroupContent>
@@ -205,77 +205,77 @@
                         <SidebarMenuSub>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/buttons" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Button</span></a>
+                                    <a href="/components/buttons" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Button</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/button-group" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Button Group</span></a>
+                                    <a href="/components/button-group" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Button Group</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/calendar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Calendar</span></a>
+                                    <a href="/components/calendar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Calendar</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>         
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/calendar-provider" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Calendar Provider</span></a>
+                                    <a href="/components/calendar-provider" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Calendar Provider</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>                             
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/checkbox" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Checkbox</span></a>
+                                    <a href="/components/checkbox" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Checkbox</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/combobox" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Combobox</span></a>
+                                    <a href="/components/combobox" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Combobox</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/color-picker" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Color Picker</span></a>
+                                    <a href="/components/color-picker" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Color Picker</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/color-swatch" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Color Swatch</span></a>
+                                    <a href="/components/color-swatch" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Color Swatch</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/file-input" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>File Input</span></a>
+                                    <a href="/components/file-input" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>File Input</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/input" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Input</span></a>
+                                    <a href="/components/input" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Input</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/input-otp" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Input OTP</span></a>
+                                    <a href="/components/input-otp" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Input OTP</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/native-select" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Native Select</span></a>
+                                    <a href="/components/native-select" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Native Select</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>                            
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/radiogroup" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Radio Group</span></a>
+                                    <a href="/components/radiogroup" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Radio Group</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/switch" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Switch</span></a>
+                                    <a href="/components/switch" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Switch</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                             <SidebarMenuItem>
                                 <SidebarMenuButton AsChild>
-                                    <a href="/components/toggle" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Toggle</span></a>
+                                    <a href="/components/toggle" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Toggle</span></a>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                         </SidebarMenuSub>
@@ -285,18 +285,18 @@
                             <a href="#" class="font-medium">Navigation</a>
                         </SidebarMenuButton>
                         <SidebarMenuSub>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/breadcrumb" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Breadcrumb</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/collapsible" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Collapsible</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/command" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Command</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/dropdown" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Dropdown Menu</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/link" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Link</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/menubar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Menubar</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/navigation-menu" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Navigation Menu</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/scroll-area" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Scroll Area</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/popover" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Popover</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/pagination" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Pagination</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/sidebar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Sidebar</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/tabs" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Tabs</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/breadcrumb" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Breadcrumb</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/collapsible" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Collapsible</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/command" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Command</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/dropdown" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Dropdown Menu</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/link" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Link</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/menubar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Menubar</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/navigation-menu" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Navigation Menu</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/scroll-area" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Scroll Area</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/popover" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Popover</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/pagination" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Pagination</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/sidebar" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Sidebar</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/tabs" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Tabs</span></a></SidebarMenuButton></SidebarMenuItem>
                         </SidebarMenuSub>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
@@ -304,11 +304,11 @@
                             <a href="#" class="font-medium">Layout</a>
                         </SidebarMenuButton>
                         <SidebarMenuSub>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/accordion" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Accordion</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/aspect-ratio" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Aspect Ratio</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/card" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Card</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/carousel" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Carousel</span></a></SidebarMenuButton></SidebarMenuItem>
-                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/markdown" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML" x-on:click="close" aria-current="page"><span>Markdown</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/accordion" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Accordion</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/aspect-ratio" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Aspect Ratio</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/card" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Card</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/carousel" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Carousel</span></a></SidebarMenuButton></SidebarMenuItem>
+                            <SidebarMenuItem><SidebarMenuButton AsChild><a href="/components/markdown" hx-boost="true" hx-select="#content" hx-target="#content" hx-swap="outerHTML show:window:top" x-on:click="close" aria-current="page"><span>Markdown</span></a></SidebarMenuButton></SidebarMenuItem>
                         </SidebarMenuSub>
                     </SidebarMenuItem>
                 </SidebarMenu>


### PR DESCRIPTION
Ensures that when navigating to new documentation or component pages via the sidebar, the page automatically scrolls to the top.

This improves the user experience by consistently presenting new content from its beginning, preventing users from landing in the middle of a page after an Htmx content swap.