### PR TITLE
test: configure localization for web app fixture

### DIFF
--- a/src/RizzyUI.Tests/Assets/Alba/WebAppFixture.cs
+++ b/src/RizzyUI.Tests/Assets/Alba/WebAppFixture.cs
@@ -1,6 +1,8 @@
+using System.Globalization;
 using Alba;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Rizzy;
@@ -24,7 +26,24 @@ public sealed class WebAppFixture : IAsyncLifetime
         builder.Services.AddSingleton(httpContextAccessorMock.Object);
 
         builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
+        builder.Services.Configure<RequestLocalizationOptions>(options =>
+        {
+            var supportedCultures = new[]
+            {
+                new CultureInfo("en"),
+                new CultureInfo("de"),
+                new CultureInfo("es"),
+                new CultureInfo("fr"),
+                new CultureInfo("pt")
+            };
 
+            options.DefaultRequestCulture = new RequestCulture("en");
+            options.SupportedCultures = supportedCultures;
+            options.SupportedUICultures = supportedCultures;
+        });
+
+        SetCulture("en");
+        
         builder.Services.AddRizzy();
         builder.Services.AddHtmx(config =>
         {
@@ -42,6 +61,16 @@ public sealed class WebAppFixture : IAsyncLifetime
         {
         });
     }
+    
+    protected static void SetCulture(string cultureName)
+    {
+        var culture = CultureInfo.GetCultureInfo(cultureName);
+
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+    }    
 
     public Task DisposeAsync() => Host.DisposeAsync().AsTask();
 }


### PR DESCRIPTION
Set up a robust localization pipeline for the test server. Defined a set of supported cultures and established a default. Added a helper to consistently set the current culture for test runs. This ensures test stability and enables localization-dependent test cases.